### PR TITLE
Offline/Guest mode

### DIFF
--- a/lib/controller/Auth.dart
+++ b/lib/controller/Auth.dart
@@ -136,4 +136,11 @@ class Auth {
     this._session = null;
     this._userEmail = null;
   }
+
+  bool isLoggedIn() {
+    if (this._user == null || this._session == null) {
+      return false;
+    }
+    return this._session.isValid();
+  }
 }

--- a/lib/page/LandingPage.dart
+++ b/lib/page/LandingPage.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:project_apraxia/controller/LocalWSDCalculator.dart';
+import 'package:project_apraxia/page/AmbiancePage.dart';
 import 'package:project_apraxia/page/SettingsPage.dart';
 import 'package:project_apraxia/page/SelectWaiverPage.dart';
 import 'package:project_apraxia/page/HowToPage.dart';
@@ -30,16 +32,16 @@ class LandingPage extends StatelessWidget {
                         minWidth: 250.0,
                         child: RaisedButton(
                           color: Theme.of(context).buttonColor,
-                          child: Text("How To", style: TextStyle(fontSize: 20)),
-                          onPressed: () => goToHowToPage(context),
+                          child: Text("Start WSD Calculation",
+                              style: TextStyle(fontSize: 20)),
+                          onPressed: () => goToRecordPage(context),
                         )),
                     ButtonTheme(
                         minWidth: 250.0,
                         child: RaisedButton(
                           color: Theme.of(context).buttonColor,
-                          child: Text("Start WSD Calculation",
-                              style: TextStyle(fontSize: 20)),
-                          onPressed: () => goToRecordPage(context),
+                          child: Text("How To", style: TextStyle(fontSize: 20)),
+                          onPressed: () => goToHowToPage(context),
                         )),
                     ButtonTheme(
                         minWidth: 250.0,
@@ -65,8 +67,18 @@ class LandingPage extends StatelessWidget {
 }
 
 void goToRecordPage(BuildContext context) {
-  Navigator.of(context)
-      .push(MaterialPageRoute(builder: (context) => SelectWaiverPage()));
+  if(Auth.instance().isLoggedIn()) {
+    Navigator.of(context)
+        .push(MaterialPageRoute(builder: (context) => SelectWaiverPage()));
+  }
+  else {
+    Navigator.of(context)
+        .push(MaterialPageRoute(builder: (context) =>
+          AmbiancePage(
+              wsdCalculator: new LocalWSDCalculator()
+          )
+    ));
+  }
 }
 
 void goToSettingsPage(BuildContext context) {

--- a/lib/page/SettingsPage.dart
+++ b/lib/page/SettingsPage.dart
@@ -1,32 +1,55 @@
 import 'package:flutter/material.dart';
 import 'package:project_apraxia/widget/form/InvalidateWaiverForm.dart';
-
 import 'package:project_apraxia/widget/form/UpdateUserForm.dart';
+import 'package:project_apraxia/controller/Auth.dart';
 
 class SettingsPage extends StatelessWidget {
+  final bool isLoggedIn = Auth.instance().isLoggedIn();
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 3,
+      length: isLoggedIn ? 3 : 1,
       child: Scaffold(
         appBar: AppBar(
           title: Text("Settings"),
           bottom: TabBar(
-            tabs: <Widget>[
-              Tab(child: Text("Account")),
-              Tab(child: Text("Prompts")),
-              Tab(child: Text("Waivers"))
-            ],
+            tabs: _buildTabBar(isLoggedIn)
           ),
         ),
         body: TabBarView(
-          children: <Widget>[
-            UpdateUserForm(),
-            Container(),
-            InvalidateWaiverForm()
-          ],
+          children: _buildTabBarView(isLoggedIn)
         ),
       ),
     );
+  }
+
+  List<Widget> _buildTabBar(bool isLoggedIn) {
+    if (isLoggedIn) {
+      return <Widget> [
+        Tab(child: Text("Account")),
+        Tab(child: Text("Prompts")),
+        Tab(child: Text("Waivers"))
+      ];
+    }
+    else {
+      return <Widget> [
+        Tab(child: Text("Prompts")),
+      ];
+    }
+  }
+
+  List<Widget> _buildTabBarView(bool isLoggedIn) {
+    if (isLoggedIn) {
+      return [
+        UpdateUserForm(),
+        Container(),
+        InvalidateWaiverForm()
+      ];
+    }
+    else {
+      return [
+        Container(),
+      ];
+    }
   }
 }

--- a/lib/page/SignInPage.dart
+++ b/lib/page/SignInPage.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:project_apraxia/page/LandingPage.dart';
 import 'package:project_apraxia/page/SignUpPage.dart';
 import 'package:project_apraxia/widget/form/SignInForm.dart';
 
@@ -18,9 +19,18 @@ class _SignInPageState extends State<SignInPage> {
               Container(
                 child: SignInForm(),
               ),
-              FlatButton(
-                child: Text("Sign Up"),
-                onPressed: () => goToSignUp(context),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  FlatButton(
+                    child: Text("Continue as Guest"),
+                    onPressed: () => guestLogin(context),
+                  ),
+                  FlatButton(
+                    child: Text("Sign Up"),
+                    onPressed: () => goToSignUp(context),
+                  )
+                ],
               )
             ],
           ),
@@ -29,5 +39,9 @@ class _SignInPageState extends State<SignInPage> {
 
   void goToSignUp(BuildContext context) {
     Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => SignUpPage()));
+  }
+
+  void guestLogin(BuildContext context) {
+    Navigator.of(context).push(MaterialPageRoute(builder: (context) => LandingPage()));
   }
 }

--- a/lib/widget/form/SignInForm.dart
+++ b/lib/widget/form/SignInForm.dart
@@ -40,14 +40,19 @@ class SignInForm extends StatelessWidget {
               },
             ),
           ),
-          RaisedButton(
-            child: Text("Sign In"),
-            onPressed: () => signIn(context),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              FlatButton(
+                child: Text("Forgot Password?"),
+                onPressed: () => sendForgotPassword(context),
+              ),
+              RaisedButton(
+                child: Text("Sign In"),
+                onPressed: () => signIn(context),
+              )
+            ],
           ),
-          FlatButton(
-            child: Text("Forgot Password"),
-            onPressed: () => sendForgotPassword(context),
-          )
         ],
       ),
     );


### PR DESCRIPTION
In this pull request:
- Added a "continue as guest" button to home screen that bypasses the sign in process
- Added a method to the Auth class to check if the user is logged in.
- Used that method to alter rendering of settings menu to not show account settings or the waiver checker
- When not logged in, and you press the start test button, it immediately moves to the ambiance page with a local WSDCalculator

P.S. Make sure it actually works on your device before approving the pull request.